### PR TITLE
Add Azure ML train and deploy workflow

### DIFF
--- a/.github/workflows/azure-ml.yml
+++ b/.github/workflows/azure-ml.yml
@@ -1,0 +1,62 @@
+name: Azure ML Train and Deploy
+
+on:
+  workflow_dispatch:
+
+jobs:
+  train:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: "3.9"
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r azure-ml/requirements.txt
+
+      - name: Azure login
+        uses: azure/login@v1
+        with:
+          creds: ${{ secrets.AZURE_CREDENTIALS }}
+
+      - name: Train model on Azure ML
+        env:
+          AZURE_SUBSCRIPTION_ID: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+          AZURE_RESOURCE_GROUP: ${{ secrets.AZURE_RESOURCE_GROUP }}
+          AZURE_WORKSPACE_NAME: ${{ secrets.AZURE_WORKSPACE_NAME }}
+        run: |
+          python azure-ml/train.py
+
+  deploy:
+    runs-on: ubuntu-latest
+    needs: train
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: "3.9"
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r azure-ml/requirements.txt
+
+      - name: Azure login
+        uses: azure/login@v1
+        with:
+          creds: ${{ secrets.AZURE_CREDENTIALS }}
+
+      - name: Deploy to Azure ML
+        env:
+          AZURE_SUBSCRIPTION_ID: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+          AZURE_RESOURCE_GROUP: ${{ secrets.AZURE_RESOURCE_GROUP }}
+          AZURE_WORKSPACE_NAME: ${{ secrets.AZURE_WORKSPACE_NAME }}
+        run: |
+          python azure-ml/deploy.py

--- a/azure-ml/config.py
+++ b/azure-ml/config.py
@@ -1,10 +1,11 @@
+import os
 from azure.ai.ml import MLClient
 from azure.identity import DefaultAzureCredential
 
-# Replace with your Azure details
-SUBSCRIPTION_ID = "3fc7fd13-533e-40a7-8e3d-f1fbf4204436"
-RESOURCE_GROUP = "edu-demo"
-WORKSPACE_NAME = "edu-demo"
+# Azure workspace details can be provided via environment variables
+SUBSCRIPTION_ID = os.getenv("AZURE_SUBSCRIPTION_ID", "3fc7fd13-533e-40a7-8e3d-f1fbf4204436")
+RESOURCE_GROUP = os.getenv("AZURE_RESOURCE_GROUP", "edu-demo")
+WORKSPACE_NAME = os.getenv("AZURE_WORKSPACE_NAME", "edu-demo")
 
 # Initialize ML Client
 credential = DefaultAzureCredential()

--- a/azure-ml/deploy.py
+++ b/azure-ml/deploy.py
@@ -1,72 +1,6 @@
 import uuid
 from config import ml_client
-from azure.ai.ml import command, Input
-from azure.ai.ml.entities import AmlCompute, ManagedOnlineEndpoint, ManagedOnlineDeployment
-from datetime import datetime
-
-def create_compute():
-    """Create compute cluster in UK South and return its name"""
-    cpu_compute_target = "cpu-cluster"
-
-    try:
-        cpu_cluster = ml_client.compute.get(cpu_compute_target)
-        print(f"Found existing cluster: {cpu_cluster.name}")
-    except Exception:
-        print("Creating new compute cluster…")
-        cpu_cluster = AmlCompute(
-            name=cpu_compute_target,
-            type="amlcompute",
-            size="STANDARD_E8S_V3",
-            min_instances=0,
-            max_instances=2,
-            idle_time_before_scale_down=180,
-            tier="Dedicated",
-            location="uksouth"
-        )
-        cpu_cluster = ml_client.compute.begin_create_or_update(cpu_cluster).result()
-        print(f"Created cluster: {cpu_cluster.name}")
-
-    # ← return the name, not the object
-    return cpu_cluster.name
-
-
-def submit_training_job(compute_name: str):
-    """Submit a training job and wait for completion."""
-    job = command(
-        inputs={
-            "test_train_ratio": 0.2,
-            "n_estimators": 50,
-            "max_depth": 10,
-            "registered_model_name": "iris_model",
-        },
-        code="./src/",
-        command=(
-            "python main.py "
-            "--test_train_ratio ${{inputs.test_train_ratio}} "
-            "--n_estimators ${{inputs.n_estimators}} "
-            "--max_depth ${{inputs.max_depth}} "
-            "--registered_model_name ${{inputs.registered_model_name}}"
-        ),
-        environment="AzureML-sklearn-1.0-ubuntu20.04-py38-cpu@latest",
-        compute=compute_name,
-        experiment_name="iris-training-experiment",
-        display_name="iris_classification_training",
-    )
-
-    # submit and stream logs
-    job = ml_client.jobs.create_or_update(job)
-    print(f"Job submitted: {job.name}")
-    print("Waiting for training job to complete…")
-    ml_client.jobs.stream(job.name)
-
-    # check final status
-    completed = ml_client.jobs.get(job.name)
-    print(f"Job status: {completed.status}")
-    if completed.status != "Completed":
-        raise Exception(f"Training job failed: {completed.status}")
-    print("✅ Training job completed successfully")
-    return job.name
-
+from azure.ai.ml.entities import ManagedOnlineEndpoint, ManagedOnlineDeployment
 
 def list_registered_models():
     """List all registered models with None-safe version handling"""
@@ -164,20 +98,13 @@ def test_endpoint(endpoint_name):
     return response
 
 if __name__ == "__main__":
-    # Complete workflow
-    print("Step 1: Creating compute cluster...")
-    compute_name = create_compute()
-    
-    print("\nStep 2: Submitting training job...")
-    job = submit_training_job(compute_name)
-    
-    print("\nStep 3: Creating endpoint...")
+    print("Step 1: Creating endpoint...")
     endpoint_name = create_endpoint()
-    
-    print("\nStep 4: Deploying model...")
+
+    print("\nStep 2: Deploying model...")
     deploy_model(endpoint_name)
-    
-    print("\nStep 5: Testing endpoint...")
+
+    print("\nStep 3: Testing endpoint...")
     test_endpoint(endpoint_name)
-    
+
     print(f"\nDeployment complete! Endpoint name: {endpoint_name}")

--- a/azure-ml/train.py
+++ b/azure-ml/train.py
@@ -1,0 +1,75 @@
+from config import ml_client
+from azure.ai.ml import command
+from azure.ai.ml.entities import AmlCompute
+
+
+def create_compute():
+    """Create compute cluster in UK South and return its name"""
+    cpu_compute_target = "cpu-cluster"
+
+    try:
+        cpu_cluster = ml_client.compute.get(cpu_compute_target)
+        print(f"Found existing cluster: {cpu_cluster.name}")
+    except Exception:
+        print("Creating new compute cluster…")
+        cpu_cluster = AmlCompute(
+            name=cpu_compute_target,
+            type="amlcompute",
+            size="STANDARD_E8S_V3",
+            min_instances=0,
+            max_instances=2,
+            idle_time_before_scale_down=180,
+            tier="Dedicated",
+            location="uksouth",
+        )
+        cpu_cluster = ml_client.compute.begin_create_or_update(cpu_cluster).result()
+        print(f"Created cluster: {cpu_cluster.name}")
+
+    return cpu_cluster.name
+
+
+def submit_training_job(compute_name: str):
+    """Submit a training job and wait for completion."""
+    job = command(
+        inputs={
+            "test_train_ratio": 0.2,
+            "n_estimators": 50,
+            "max_depth": 10,
+            "registered_model_name": "iris_model",
+        },
+        code="./src/",
+        command=(
+            "python main.py "
+            "--test_train_ratio ${{inputs.test_train_ratio}} "
+            "--n_estimators ${{inputs.n_estimators}} "
+            "--max_depth ${{inputs.max_depth}} "
+            "--registered_model_name ${{inputs.registered_model_name}}"
+        ),
+        environment="AzureML-sklearn-1.0-ubuntu20.04-py38-cpu@latest",
+        compute=compute_name,
+        experiment_name="iris-training-experiment",
+        display_name="iris_classification_training",
+    )
+
+    job = ml_client.jobs.create_or_update(job)
+    print(f"Job submitted: {job.name}")
+    print("Waiting for training job to complete…")
+    ml_client.jobs.stream(job.name)
+
+    completed = ml_client.jobs.get(job.name)
+    print(f"Job status: {completed.status}")
+    if completed.status != "Completed":
+        raise Exception(f"Training job failed: {completed.status}")
+    print("✅ Training job completed successfully")
+    return job.name
+
+
+if __name__ == "__main__":
+    print("Step 1: Creating compute cluster...")
+    compute_name = create_compute()
+
+    print("\nStep 2: Submitting training job...")
+    submit_training_job(compute_name)
+
+    print("\nTraining complete")
+


### PR DESCRIPTION
## Summary
- split training logic into dedicated Azure ML script
- streamline deploy script to only create endpoint and deploy latest model
- update GitHub Actions workflow to run training before deployment

## Testing
- `python -m py_compile azure-ml/config.py azure-ml/train.py azure-ml/deploy.py`


------
https://chatgpt.com/codex/tasks/task_e_68aae7069738832889a9ed5b42c1887e